### PR TITLE
Add Google Play release workflow

### DIFF
--- a/.github/workflows/google_play_release.yml
+++ b/.github/workflows/google_play_release.yml
@@ -1,0 +1,41 @@
+name: Deploy to Google Play
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    types: [ closed ]
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'dev'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+          cache: gradle
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build release bundle
+        run: ./gradlew bundleRelease --warning-mode=none
+      - name: Sign bundle
+        id: sign
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: app/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          alias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      - name: Upload to Google Play
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.hashan0314.veritasdaily
+          releaseFiles: ${{ steps.sign.outputs.signedReleaseFile }}
+          track: production
+

--- a/.github/workflows/google_play_release.yml
+++ b/.github/workflows/google_play_release.yml
@@ -1,4 +1,6 @@
 name: Deploy to Google Play
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
- add a workflow to deploy a signed release to Google Play when `dev` merges into `master`

## Testing
- `./gradlew build -x test` *(fails: SDK location not found)*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b107dcc088324951ce61cc48d8adc