### PR TITLE
Add wiki pages based on README sections

### DIFF
--- a/wiki/Acknowledgments.md
+++ b/wiki/Acknowledgments.md
@@ -1,0 +1,5 @@
+## Acknowledgments
+
+- Daily Gospel from [Vatican News](https://www.vaticannews.va)
+- Icons by [Material Design Icons](https://material.io/resources/icons/)
+- Thanks to the open-source community and contributors!

--- a/wiki/Code-Quality.md
+++ b/wiki/Code-Quality.md
@@ -1,0 +1,7 @@
+## Code Quality
+
+Pushes and pull requests to the **dev** and **master** branches trigger a [SonarCloud](https://sonarcloud.io) analysis. Configure the `SONAR_TOKEN` secret in your repository to enable the workflow.
+
+The SonarCloud quality gate status is posted back on each pull request.
+
+Android Lint checks run on pull requests targeting the **dev** or **master** branch and comment lint issues with a link to the full report.

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,0 +1,9 @@
+## Contributing
+
+1. Fork the repo.
+2. Create a branch: `git checkout -b feature/my-feature`
+3. Commit changes: `git commit -m 'Added my feature'`
+4. Push the branch: `git push origin feature/my-feature`
+5. Open a Pull Request.
+
+Make sure your code follows existing styles and includes relevant tests.

--- a/wiki/Dependencies.md
+++ b/wiki/Dependencies.md
@@ -1,0 +1,12 @@
+## Dependencies
+
+Key dependencies include:
+
+- AndroidX Core Libraries
+- Material Components
+- Retrofit & OkHttp *(if used)*
+- Gson / Moshi / Kotlinx Serialization *(if used)*
+- Kotlin Coroutines
+- Glide / Picasso *(if used)*
+
+> Full list available in `app/build.gradle`.

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -1,0 +1,21 @@
+## Features
+
+- **Daily Gospel:**
+    - Displays daily gospel readings via Vatican News RSS feed.
+    - Includes loading indicators and graceful error handling.
+
+- **Holy Rosary:**
+    - Interactive Rosary guide.
+    - Includes all Mysteries (Joyful, Luminous, Sorrowful, Glorious).
+    - Expandable prayer sections.
+
+- **Navigation:**
+    - Navigation Drawer for simple screen access.
+    - Toolbar with options menu.
+
+- **User Interface:**
+    - Light and Dark Mode.
+    - Based on Material Design.
+
+- **About Page:**
+    - Details about the app, data sources, and version info.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,16 @@
+# Veritas Daily - Android App
+
+**Veritas Daily** is a spiritual companion Android application for daily prayer and reflection. It includes features such as the Holy Rosary, Daily Gospel readings (sourced from Vatican News), and an About section for more context on its usage and content.
+
+## Pages
+
+- [Features](Features.md)
+- [Screenshots](Screenshots.md)
+- [Tech Stack & Architecture](Tech-Stack-Architecture.md)
+- [Setup & Build](Setup-and-Build.md)
+- [Project Structure](Project-Structure.md)
+- [Dependencies](Dependencies.md)
+- [Code Quality](Code-Quality.md)
+- [Contributing](Contributing.md)
+- [License](License.md)
+- [Acknowledgments](Acknowledgments.md)

--- a/wiki/License.md
+++ b/wiki/License.md
@@ -1,0 +1,4 @@
+## License
+
+This project is licensed under the **[Your License Here]**.
+See [LICENSE](../LICENSE) for more information.

--- a/wiki/Project-Structure.md
+++ b/wiki/Project-Structure.md
@@ -1,0 +1,29 @@
+## Project Structure
+
+```
+BibleMate/
+├── app/
+│   └── src/
+│       └── main/
+│           ├── java/com/hashan0314/veritasdaily/
+│           │   ├── model/
+│           │   ├── network/
+│           │   ├── repository/
+│           │   └── ui/
+│           │       ├── adapter/
+│           │       ├── fragment/
+│           │       ├── viewmodel/
+│           │       └── MainActivity.kt
+│           ├── res/
+│           │   ├── layout/
+│           │   ├── drawable/
+│           │   ├── menu/
+│           │   ├── navigation/
+│           │   └── values/
+│           └── AndroidManifest.xml
+├── .github/
+│   └── workflows/
+│       └── android_build.yml
+├── build.gradle
+└── settings.gradle
+```

--- a/wiki/Screenshots.md
+++ b/wiki/Screenshots.md
@@ -1,0 +1,9 @@
+## Screenshots
+
+<div align="center" style="display: flex; flex-wrap: wrap; justify-content: center; gap: 20px;">
+    <img src=".github/screenshots/Screenshot_20250608_191211.png" width="200" alt="Launch Screen">
+    <img src=".github/screenshots/Screenshot_20250608_191237.png" width="200" alt="Gospel Screen">
+    <img src=".github/screenshots/Screenshot_20250608_191309.png" width="200" alt="Navigation Screen">
+    <img src=".github/screenshots/Screenshot_20250608_191339.png" width="200" alt="Rosary Screen 1">
+    <img src=".github/screenshots/Screenshot_20250608_191406.png" width="200" alt="Rosary Screen 2">
+</div>

--- a/wiki/Setup-and-Build.md
+++ b/wiki/Setup-and-Build.md
@@ -1,0 +1,25 @@
+## Setup & Build
+
+### Prerequisites
+
+- Android Studio (2023.2.1+ Iguana)
+- Android SDK (Target SDK: 35)
+- JDK 17 or higher
+
+### Cloning
+
+```bash
+git clone https://github.com/hashansilva/BibleMate.git
+cd BibleMate
+```
+
+### Building
+
+1. Open the project in Android Studio.
+2. Let it sync Gradle and fetch dependencies.
+3. Click **Run** or go to **Build > Make Project**.
+
+#### Generate Signed APK/AAB
+
+1. Follow the [official Android guide](https://developer.android.com/studio/publish/app-signing).
+2. Use **Build > Generate Signed Bundle / APK...**

--- a/wiki/Tech-Stack-Architecture.md
+++ b/wiki/Tech-Stack-Architecture.md
@@ -1,0 +1,11 @@
+## Tech Stack & Architecture
+
+- **Language:** Kotlin
+- **Architecture:** MVVM (Model-View-ViewModel)
+- **Jetpack Components:**
+    - **UI Layer:** Fragments, View Binding / Data Binding, RecyclerView, Navigation Component
+    - **Data Layer:** Repository Pattern, Retrofit *(if used)*, Room *(if applicable)*
+    - **Lifecycle:** ViewModel, LiveData / Kotlin Flows
+- **Coroutines:** Kotlin Coroutines
+- **DI (Dependency Injection):** *Specify if Hilt, Koin, or manual*
+- **Testing Frameworks:** *Specify e.g., JUnit, Mockito, Espresso*


### PR DESCRIPTION
## Summary
- add `wiki` directory with separate markdown pages
- move content from README into pages: Features, Screenshots, Tech Stack & Architecture, Setup & Build, Project Structure, Dependencies, Code Quality, Contributing, License, and Acknowledgments
- include a `Home.md` that links to each page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685cf903e8688324bd7bb00a335527c0