### PR TITLE
Add unit tests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ About section for more context on its usage and content.
     - **Lifecycle:** ViewModel, LiveData / Kotlin Flows
 - **Coroutines:** Kotlin Coroutines
 - **DI (Dependency Injection):** *Specify if Hilt, Koin, or manual*
-- **Testing Frameworks:** *Specify e.g., JUnit, Mockito, Espresso*
+- **Testing Frameworks:** JUnit 4 for unit tests and Espresso for UI testing
 
 ---
 
@@ -103,7 +103,12 @@ cd BibleMate
 
 1. Follow the [official Android guide](https://developer.android.com/studio/publish/app-signing).
 2. Use **Build > Generate Signed Bundle / APK...**
+### Running Tests
 
+Run unit tests with:
+```bash
+./gradlew test
+```
 ---
 
 ## Project Structure

--- a/app/src/test/java/com/hashan0314/veritasdaily/GospelDiffCallbackTest.kt
+++ b/app/src/test/java/com/hashan0314/veritasdaily/GospelDiffCallbackTest.kt
@@ -1,0 +1,39 @@
+package com.hashan0314.veritasdaily
+
+import com.hashan0314.veritasdaily.model.Item
+import com.hashan0314.veritasdaily.ui.adapter.GospelDiffCallback
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GospelDiffCallbackTest {
+    private val callback = GospelDiffCallback()
+
+    @Test
+    fun itemsWithSameGuidAreTreatedAsSame() {
+        val oldItem = Item(description = "a", guid = "1", pubDate = "date1")
+        val newItem = Item(description = "b", guid = "1", pubDate = "date2")
+        assertTrue(callback.areItemsTheSame(oldItem, newItem))
+    }
+
+    @Test
+    fun itemsWithDifferentGuidAreNotSame() {
+        val oldItem = Item(guid = "1")
+        val newItem = Item(guid = "2")
+        assertFalse(callback.areItemsTheSame(oldItem, newItem))
+    }
+
+    @Test
+    fun identicalItemsAreRecognizedAsSameContent() {
+        val oldItem = Item(description = "desc", guid = "1", pubDate = "date")
+        val newItem = Item(description = "desc", guid = "1", pubDate = "date")
+        assertTrue(callback.areContentsTheSame(oldItem, newItem))
+    }
+
+    @Test
+    fun itemsWithDifferentFieldsAreNotSameContent() {
+        val oldItem = Item(description = "desc", guid = "1", pubDate = "date")
+        val newItem = Item(description = "other", guid = "1", pubDate = "date")
+        assertFalse(callback.areContentsTheSame(oldItem, newItem))
+    }
+}

--- a/app/src/test/java/com/hashan0314/veritasdaily/RosaryDiffCallbackTest.kt
+++ b/app/src/test/java/com/hashan0314/veritasdaily/RosaryDiffCallbackTest.kt
@@ -1,0 +1,48 @@
+package com.hashan0314.veritasdaily
+
+import com.hashan0314.veritasdaily.model.MysterySetHeaderData
+import com.hashan0314.veritasdaily.model.RosaryMystery
+import com.hashan0314.veritasdaily.model.StandardPrayer
+import com.hashan0314.veritasdaily.ui.adapter.RosaryDiffCallback
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RosaryDiffCallbackTest {
+    private val callback = RosaryDiffCallback()
+
+    @Test
+    fun standardPrayersWithSameIdAreSameItem() {
+        val old = StandardPrayer("id","title","text")
+        val new = StandardPrayer("id","other","text2")
+        assertTrue(callback.areItemsTheSame(old, new))
+    }
+
+    @Test
+    fun rosaryMysteriesWithSameIdAreSameItem() {
+        val old = RosaryMystery("id","title","cap","desc","fruit")
+        val new = RosaryMystery("id","t","c","d","fruit")
+        assertTrue(callback.areItemsTheSame(old, new))
+    }
+
+    @Test
+    fun differentTypesAreNotTheSame() {
+        val prayer = StandardPrayer("id","title","content")
+        val mystery = RosaryMystery("other","t","c","d","f")
+        assertFalse(callback.areItemsTheSame(prayer, mystery))
+    }
+
+    @Test
+    fun identicalHeaderDataAreSameContent() {
+        val old = MysterySetHeaderData("h1","Glorious","Mondays", true)
+        val new = MysterySetHeaderData("h1","Glorious","Mondays", true)
+        assertTrue(callback.areContentsTheSame(old, new))
+    }
+
+    @Test
+    fun headerDataWithDifferentExpansionStateAreNotSameContent() {
+        val old = MysterySetHeaderData("h1","Glorious","Mondays", true)
+        val new = MysterySetHeaderData("h1","Glorious","Mondays", false)
+        assertFalse(callback.areContentsTheSame(old, new))
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit tests for the diff util callbacks
- document testing frameworks and how to run tests

## Testing
- `./gradlew test --no-daemon` *(fails: missing Android SDK components)*

------
https://chatgpt.com/codex/tasks/task_b_68696a0b24e88324b23c52c41e881d87